### PR TITLE
Do not use file modified time to determine when to upload files

### DIFF
--- a/src/main/kotlin/fi/hsl/transitdata/eke_sink/MessageHandler.kt
+++ b/src/main/kotlin/fi/hsl/transitdata/eke_sink/MessageHandler.kt
@@ -21,7 +21,7 @@ import java.util.*
 
 const val TOPIC_PREFIX = "eke/v1/sm5/"
 
-class MessageHandler(context: PulsarApplicationContext, fileDirectory: Path) : IMessageHandler {
+class MessageHandler(context: PulsarApplicationContext, fileDirectory: Path, addToUploadList: (Path) -> Unit) : IMessageHandler {
     private val log = KotlinLogging.logger {}
 
     private val consumer: Consumer<ByteArray> = context.consumer!!
@@ -30,7 +30,7 @@ class MessageHandler(context: PulsarApplicationContext, fileDirectory: Path) : I
 
     private val producer : Producer<ByteArray>? = if (context.config!!.getBoolean("pulsar.producer.enabled")) { context.singleProducer!! } else { null }
 
-    private val csvHelper = CSVHelper(fileDirectory, Duration.ofMinutes(30), listOf("message_type", "ntp_timestamp", "ntp_ok", "eke_timestamp", "mqtt_timestamp", "mqtt_topic", "raw_data"))
+    private val csvHelper = CSVHelper(fileDirectory, Duration.ofMinutes(30), listOf("message_type", "ntp_timestamp", "ntp_ok", "eke_timestamp", "mqtt_timestamp", "mqtt_topic", "raw_data"), addToUploadList)
 
     private val fileToMsgId = mutableMapOf<Path, MutableList<MessageId>>()
     

--- a/src/test/kotlin/CSVHelperTest.kt
+++ b/src/test/kotlin/CSVHelperTest.kt
@@ -20,10 +20,12 @@ class CSVHelperTest {
     private lateinit var directory: Path
     private lateinit var csvHelper: CSVHelper
 
+    private val readyToUpload = mutableSetOf<Path>()
+
     @Before
     fun setup() {
         directory = temporaryFolder.newFolder().toPath()
-        csvHelper = CSVHelper(directory, Duration.ofSeconds(2), listOf("a", "b"))
+        csvHelper = CSVHelper(directory, Duration.ofSeconds(2), listOf("a", "b"), readyToUpload::add)
     }
 
     @ExperimentalPathApi
@@ -42,5 +44,15 @@ class CSVHelperTest {
         assertEquals("a,b", content[0])
         assertEquals("1,2", content[1])
         assertEquals("3,4", content[2])
+    }
+
+    @Test
+    fun `Test file is added to upload list after closing`() {
+        csvHelper.writeToCsv("test", listOf("1", "2"))
+
+        Thread.sleep(3000)
+
+        assertEquals(1, readyToUpload.size)
+        assertTrue(readyToUpload.contains(directory.resolve("test.csv")))
     }
 }

--- a/src/test/kotlin/MessageHandlerTest.kt
+++ b/src/test/kotlin/MessageHandlerTest.kt
@@ -61,7 +61,7 @@ class MessageHandlerTest {
             Files.createDirectories(directory)
         }
 
-        val handler = MessageHandler(mockContext, directory)
+        val handler = MessageHandler(mockContext, directory, {})
         handler.handleMessage(mock<Message<Any>> {
             on { data } doAnswer { Mqtt.RawMessage.newBuilder().setPayload(ByteString.copyFrom(getMessageContent())).setTopic("eke/v1/sm5/15/A/stadlerUDP").setSchemaVersion(1).build().toByteArray() }
             on { properties } doReturn(Collections.singletonMap(fi.hsl.common.transitdata.TransitdataProperties.KEY_SOURCE_MESSAGE_TIMESTAMP_MS, java.time.Instant.now().toEpochMilli().toString()))


### PR DESCRIPTION
This change makes sure that files are closed before they are uploaded. This fixes disk space being filled up by files that are deleted, but still have their file descriptor open.